### PR TITLE
Update Readme.md, use int instead of number

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ parse-int =
         `s => parseInt(s, 10)`
     else
         funct(s)
-            0/0
+            0
         end
     end;
 ```


### PR DESCRIPTION
Shouldn't this "return" `0` instead of `0/0`, since `parse-int` should return an integer?